### PR TITLE
Fixed Uguu functionality and added unit tests for Pomf

### DIFF
--- a/pyupload/tests/upload_test.py
+++ b/pyupload/tests/upload_test.py
@@ -17,7 +17,7 @@ def generate_random_file_content():
 class TestUploadMethods(unittest.TestCase):
     def setUp(self):
         self.content = generate_random_file_content()
-        self.filename = 'testfile'
+        self.filename = 'testfile.txt'
         with open(self.filename, 'w') as f:
             f.write(self.content)
 
@@ -30,6 +30,11 @@ class TestUploadMethods(unittest.TestCase):
 
     def test_catbox(self):
         uploader = CatboxUploader(self.filename)
+        result = uploader.execute()
+        self.compare(result)
+
+    def test_pomf(self):
+        uploader = PomfUploader(self.filename)
         result = uploader.execute()
         self.compare(result)
 

--- a/pyupload/uploader/uguu.py
+++ b/pyupload/uploader/uguu.py
@@ -4,14 +4,14 @@ from pyupload.uploader.base import Uploader
 class UguuUploader(Uploader):
     def __init__(self, filename):
         self.filename = filename
-        self.file_host_url = "https://uguu.se/api.php?d=upload-tool"
+        self.file_host_url = 'https://uguu.se/upload'
 
     def execute(self):
         file = open(self.filename, 'rb')
         try:
-            data = {'file': (file.name, file, self._mimetype())}
+            data = {'files[]': (file.name, file, self._mimetype())}
             response = self._multipart_post(data)
         finally:
             file.close()
 
-        return response.text
+        return response.json()['files'][0]['url']

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='PyUpload',
-    version='0.1.5',
+    version='0.1.6',
     packages=find_packages(),
     author='yukinotenshi',
     author_email='gabriel.bentara@gmail.com',


### PR DESCRIPTION
* Uguu's upload endpoint and how it accepts files were changed at some point in time. Last time I submitted a [PR](https://github.com/yukinotenshi/pyupload/pull/5), Uguu was down so I couldn't test it.

* Added an extension (txt) to the file in the unit tests.

* Added a unit test for Pomf.

* Changed version to 0.1.6 from 0.1.5 as I felt the changes were sufficient enough to warrant it.

If possible at all, please update the package for PyPI.